### PR TITLE
include more error details for the context error

### DIFF
--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -63,7 +63,7 @@ func (b *BlockSimulationRateLimiter) send(context context.Context, payload *Buil
 	}()
 
 	if err := context.Err(); err != nil {
-		return ErrRequestClosed
+		return fmt.Errorf("%v, %w", ErrRequestClosed, err)
 	}
 
 	var simReq *jsonrpc.JSONRPCRequest


### PR DESCRIPTION
it would help with debugging to include the `context.Error()` that caused the context to be closed. the slightly strange thing about this is that the closure happens before the block is even sent to the prio load balancer, so a timeout (which would be my initial guess as to what caused the error) seems unlikely. 