### PR TITLE
read optimistic_submission field from db during GetBuilderSubmissions

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -378,7 +378,7 @@ func (s *DatabaseService) GetBuilderSubmissions(filters GetBuilderSubmissionsFil
 		"builder_pubkey": filters.BuilderPubkey,
 	}
 
-	fields := "id, inserted_at, received_at, eligible_at, slot, epoch, builder_pubkey, proposer_pubkey, proposer_fee_recipient, parent_hash, block_hash, block_number, num_tx, value, gas_used, gas_limit"
+	fields := "id, inserted_at, received_at, eligible_at, slot, epoch, builder_pubkey, proposer_pubkey, proposer_fee_recipient, parent_hash, block_hash, block_number, num_tx, value, gas_used, gas_limit, optimistic_submission"
 	limit := "LIMIT :limit"
 
 	whereConds := []string{

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -372,3 +372,20 @@ func TestGetBlockSubmissionEntry(t *testing.T) {
 	require.True(t, entry.OptimisticSubmission)
 	require.True(t, entry.EligibleAt.Valid)
 }
+
+func TestGetBuilderSubmissions(t *testing.T) {
+	db := resetDatabase(t)
+	pubkey := insertTestBuilder(t, db)
+
+	entries, err := db.GetBuilderSubmissions(GetBuilderSubmissionsFilters{
+		BuilderPubkey: pubkey,
+		Limit:         1,
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	e := entries[0]
+	require.Equal(t, optimisticSubmission, e.OptimisticSubmission)
+	require.Equal(t, pubkey, e.BuilderPubkey)
+	require.Equal(t, feeRecipient.String(), e.ProposerFeeRecipient)
+	require.Equal(t, fmt.Sprint(collateral), e.Value)
+}


### PR DESCRIPTION
currently, all the submissions that we return in the data API are marked as `optimistic_submission: false`: https://relay.ultrasound.money/relay/v1/data/bidtraces/builder_blocks_received?slot=6023036. this is because we don't add that extra field when reading from the db. 

included a new unit test to catch this edge case. 