### PR TITLE
context fix

### DIFF
--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -306,7 +306,7 @@ func TestProcessOptimisticBlock(t *testing.T) {
 			backend.relay.blockSimRateLimiter = &MockBlockSimulationRateLimiter{
 				simulationError: tc.simulationError,
 			}
-			backend.relay.processOptimisticBlock(context.Background(), blockSimOptions{
+			backend.relay.processOptimisticBlock(blockSimOptions{
 				isHighPrio: true,
 				log:        backend.relay.log,
 				builder: &blockBuilderCacheEntry{

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -529,12 +529,13 @@ func (api *RelayAPI) demoteBuilder(pubkey string, req *common.BuilderSubmitBlock
 
 // processOptimisticBlock is called on a new goroutine when a optimistic block
 // needs to be simulated.
-func (api *RelayAPI) processOptimisticBlock(ctx context.Context, opts blockSimOptions) {
+func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions) {
 	api.optimisticBlocksInFlight += 1
 	defer func() { api.optimisticBlocksInFlight -= 1 }()
 	api.optimisticBlocks.Add(1)
 	defer api.optimisticBlocks.Done()
 
+	ctx := context.Background()
 	builderPubkey := opts.req.BuilderPubkey().String()
 	opts.log.WithFields(logrus.Fields{
 		"builderPubkey": builderPubkey,
@@ -1477,7 +1478,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		builderEntry.status.IsOptimistic &&
 		payload.Slot() == api.optimisticSlot {
 		optimisticSubmission = true
-		go api.processOptimisticBlock(req.Context(), opts)
+		go api.processOptimisticBlock(opts)
 	} else {
 		// Simulate block (synchronously).
 		simErr = api.simulateBlock(req.Context(), opts)


### PR DESCRIPTION
we were previously using the context of the request, which can be closed by the builder. this results in a false simulation error and corresponding demotion. 

the fix is to just use our own context for optimistic blocks.