### PR TITLE
retry logic

### DIFF
--- a/services/api/mock_blocksim_ratelimiter.go
+++ b/services/api/mock_blocksim_ratelimiter.go
@@ -5,11 +5,14 @@ import (
 )
 
 type MockBlockSimulationRateLimiter struct {
-	simulationError error
+	errs []error
+	idx  int
 }
 
 func (m *MockBlockSimulationRateLimiter) send(context context.Context, payload *BuilderBlockValidationRequest, isHighPrio bool) error {
-	return m.simulationError
+	err := m.errs[m.idx]
+	m.idx += 1
+	return err
 }
 
 func (m *MockBlockSimulationRateLimiter) currentCounter() int64 {

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -317,9 +317,15 @@ func TestSimulateBlockRetries(t *testing.T) {
 			backend.relay.blockSimRateLimiter = &MockBlockSimulationRateLimiter{
 				errs: tc.errs,
 			}
+			entry := &blockBuilderCacheEntry{
+				status: common.BuilderStatus{
+					IsOptimistic: true,
+				},
+			}
 			err := backend.relay.simulateBlock(context.Background(), blockSimOptions{
 				isHighPrio: true,
 				log:        backend.relay.log,
+				builder:    entry,
 				req: &BuilderBlockValidationRequest{
 					BuilderSubmitBlockRequest: common.TestBuilderSubmitBlockRequest(
 						pubkey, secretkey, getTestBidTrace(*pubkey, collateral)),

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -496,7 +496,8 @@ func (api *RelayAPI) simulateBlock(ctx context.Context, opts blockSimOptions) er
 			"block_hash": opts.req.BlockHash,
 			"slot":       opts.req.Slot,
 		}).Warning("retrying block due to unknown ancestor")
-		simErr = api.blockSimRateLimiter.send(ctx, opts.req, opts.isHighPrio)
+		// Retry with low-prio.
+		simErr = api.blockSimRateLimiter.send(ctx, opts.req, false)
 		retryCount += 1
 		if retryCount == 3 {
 			break

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -496,11 +496,11 @@ func (api *RelayAPI) simulateBlock(ctx context.Context, opts blockSimOptions) er
 			"block_hash": opts.req.BlockHash,
 			"slot":       opts.req.Slot,
 		}).Warning("retrying block due to unknown ancestor")
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(time.Second)
 		// Retry with low-prio.
 		simErr = api.blockSimRateLimiter.send(ctx, opts.req, false)
 		retryCount += 1
-		if retryCount == 3 {
+		if retryCount == 5 {
 			break
 		}
 	}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -496,6 +496,7 @@ func (api *RelayAPI) simulateBlock(ctx context.Context, opts blockSimOptions) er
 			"block_hash": opts.req.BlockHash,
 			"slot":       opts.req.Slot,
 		}).Warning("retrying block due to unknown ancestor")
+		time.Sleep(500 * time.Millisecond)
 		// Retry with low-prio.
 		simErr = api.blockSimRateLimiter.send(ctx, opts.req, false)
 		retryCount += 1


### PR DESCRIPTION
Add retry logic (3x) to `UnknownAncestor` error, which is caused by https://github.com/michaelneuder/builder/blob/8caba1f96ff5adf5647356d231a3dcab8a74fbac/core/blockchain_reader.go#L136-L144 a geth sync issue, where the parent hash is not written to the db fast enough. 

The below shows an analysis of the logs for slot=6097258, where this error caused a number of demotions. over the last 4 seconds of the slot, we see 235 failures, and 112 successes, all with the same (correct) parentHash. the errors are intermingled with the successes. so one of the nodes must be falling out of sync.
![Screen Shot 2023-03-28 at 5 33 23 PM](https://user-images.githubusercontent.com/24661810/228380280-f5567689-7950-4d9c-8e26-818b8f8a0cf4.png)

