### PR TITLE
fix(redis): move WasBidSaved to after exec

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -639,8 +639,6 @@ func (r *RedisCache) _updateTopBid(ctx context.Context, pipeliner redis.Pipeline
 		return state, err
 	}
 
-	state.WasTopBidUpdated = state.PrevTopBidValue == nil || state.PrevTopBidValue.Cmp(state.TopBidValue) != 0
-
 	// 6. Finally, update the global top bid value
 	keyTopBidValue := r.keyTopBidValue(slot, parentHash, proposerPubkey)
 	err = pipeliner.Set(context.Background(), keyTopBidValue, state.TopBidValue.String(), expiryBidCache).Err()
@@ -649,6 +647,7 @@ func (r *RedisCache) _updateTopBid(ctx context.Context, pipeliner redis.Pipeline
 	}
 
 	_, err = pipeliner.Exec(ctx)
+	state.WasTopBidUpdated = state.PrevTopBidValue == nil || state.PrevTopBidValue.Cmp(state.TopBidValue) != 0
 	return state, err
 }
 

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -515,7 +515,6 @@ func (r *RedisCache) SaveBidAndUpdateTopBid(ctx context.Context, pipeliner redis
 	if err != nil {
 		return state, err
 	}
-	state.WasBidSaved = true
 	builderBids.bidValues[payload.BuilderPubkey().String()] = payload.Value()
 
 	// Record time needed to save bid
@@ -563,6 +562,7 @@ func (r *RedisCache) SaveBidAndUpdateTopBid(ctx context.Context, pipeliner redis
 	if err != nil {
 		return state, err
 	}
+	state.WasBidSaved = true
 
 	wasCopied, copyErr := c.Result()
 	if copyErr != nil {


### PR DESCRIPTION
We have several conditions where we don't execute the pipelined
commands. Only set the WasBidSaved flag after we execute the pipeline
successfully. Do note, if the pipeline fails we may or may not have
actually saved the bid.