### PR TITLE
feat: store payload requests

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -35,10 +35,9 @@ type GetPayloadResponseKey struct {
 
 // Datastore provides a local memory cache with a Redis and DB backend
 type Datastore struct {
-	redis        *RedisCache
-	redisArchive *RedisCache
-	memcached    *Memcached
-	db           database.IDatabaseService
+	redis     *RedisCache
+	memcached *Memcached
+	db        database.IDatabaseService
 
 	knownValidatorsByPubkey   map[types.PubkeyHex]uint64
 	knownValidatorsByIndex    map[uint64]types.PubkeyHex

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -89,7 +89,7 @@ type RedisCache struct {
 	// prefixes (keys generated with a function)
 	prefixGetHeaderResponse           string
 	prefixExecPayloadCapella          string
-	prefixExecPayloadCapellaJson      string
+	prefixExecPayloadCapellaJSON      string
 	prefixBidTrace                    string
 	prefixBlockBuilderLatestBids      string // latest bid for a given slot
 	prefixBlockBuilderLatestBidsValue string // value of latest bid for a given slot
@@ -111,7 +111,7 @@ type RedisCache struct {
 	blockSubmissionArchiveMaxLen int64
 }
 
-func NewRedisCache(prefix, redisURI, readonlyURI string, archiveURI string) (*RedisCache, error) {
+func NewRedisCache(prefix, redisURI, readonlyURI, archiveURI string) (*RedisCache, error) {
 	client, err := connectRedis(redisURI)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func NewRedisCache(prefix, redisURI, readonlyURI string, archiveURI string) (*Re
 
 		prefixGetHeaderResponse:      fmt.Sprintf("%s/%s:cache-gethead-response", redisPrefix, prefix),
 		prefixExecPayloadCapella:     fmt.Sprintf("%s/%s:cache-execpayload-capella", redisPrefix, prefix),
-		prefixExecPayloadCapellaJson: fmt.Sprintf("%s/%s:cache-execpayload-capella-json", redisPrefix, prefix),
+		prefixExecPayloadCapellaJSON: fmt.Sprintf("%s/%s:cache-execpayload-capella-json", redisPrefix, prefix),
 		prefixBidTrace:               fmt.Sprintf("%s/%s:cache-bid-trace", redisPrefix, prefix),
 
 		prefixBlockBuilderLatestBids:      fmt.Sprintf("%s/%s:block-builder-latest-bid", redisPrefix, prefix),       // hashmap for slot+parentHash+proposerPubkey with builderPubkey as field
@@ -174,8 +174,8 @@ func (r *RedisCache) keyExecPayloadCapella(slot uint64, proposerPubkey, blockHas
 	return fmt.Sprintf("%s:%d_%s_%s", r.prefixExecPayloadCapella, slot, proposerPubkey, blockHash)
 }
 
-func (r *RedisCache) keyExecPayloadCapellaJson(slot uint64, proposerPubkey, blockHash string) string {
-	return fmt.Sprintf("%s:%d_%s_%s", r.prefixExecPayloadCapellaJson, slot, proposerPubkey, blockHash)
+func (r *RedisCache) keyExecPayloadCapellaJSON(slot uint64, proposerPubkey, blockHash string) string {
+	return fmt.Sprintf("%s:%d_%s_%s", r.prefixExecPayloadCapellaJSON, slot, proposerPubkey, blockHash)
 }
 
 func (r *RedisCache) keyCacheBidTrace(slot uint64, proposerPubkey, blockHash string) string {
@@ -795,7 +795,7 @@ func (r *RedisCache) GetArchivedExecutionPayload(slot uint64, proposerPubkey, bl
 	resp := new(common.VersionedExecutionPayload)
 	capellaPayload := new(capella.ExecutionPayload)
 
-	key := r.keyExecPayloadCapellaJson(slot, proposerPubkey, blockHash)
+	key := r.keyExecPayloadCapellaJSON(slot, proposerPubkey, blockHash)
 	val, err := r.archiveClient.Get(context.Background(), key).Result()
 	if err != nil {
 		return nil, err

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -811,3 +811,15 @@ func (r *RedisCache) GetArchivedExecutionPayload(slot uint64, proposerPubkey, bl
 	resp.Capella.Version = consensusspec.DataVersionCapella
 	return resp, nil
 }
+
+func (r *RedisCache) ArchivePayloadRequest(payload []interface{}) error {
+	return r.archiveClient.XAdd(context.Background(), &redis.XAddArgs{
+		// We expect payload request logs to be at most 10 KiB in size. This
+		// means we can expect the stream to eventually take up
+		// 10_000 * 10 KiB = 100 MiB.
+		MaxLen: 10_000,
+		Approx: true,
+		Stream: "payload-request-archive",
+		Values: payload,
+	}).Err()
+}

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -26,7 +26,7 @@ func setupTestRedis(t *testing.T) *RedisCache {
 
 	redisTestServer, err := miniredis.Run()
 	require.NoError(t, err)
-	redisService, err := NewRedisCache("", redisTestServer.Addr(), "")
+	redisService, err := NewRedisCache("", redisTestServer.Addr(), "", "")
 	// redisService, err := NewRedisCache("", "localhost:6379", "")
 	require.NoError(t, err)
 
@@ -325,9 +325,9 @@ func TestRedisURIs(t *testing.T) {
 	require.NoError(t, err)
 
 	// test connection with and without protocol
-	_, err = NewRedisCache("", redisTestServer.Addr(), "")
+	_, err = NewRedisCache("", redisTestServer.Addr(), "", "")
 	require.NoError(t, err)
-	_, err = NewRedisCache("", "redis://"+redisTestServer.Addr(), "")
+	_, err = NewRedisCache("", "redis://"+redisTestServer.Addr(), "", "")
 	require.NoError(t, err)
 
 	// test connection w/ credentials
@@ -335,15 +335,15 @@ func TestRedisURIs(t *testing.T) {
 	password := "pass"
 	redisTestServer.RequireUserAuth(username, password)
 	fullURL := "redis://" + username + ":" + password + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache("", fullURL, "")
+	_, err = NewRedisCache("", fullURL, "", "")
 	require.NoError(t, err)
 
 	// ensure malformed URL throws error
 	malformURL := "http://" + username + ":" + password + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache("", malformURL, "")
+	_, err = NewRedisCache("", malformURL, "", "")
 	require.Error(t, err)
 	malformURL = "redis://" + username + ":" + "wrongpass" + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache("", malformURL, "")
+	_, err = NewRedisCache("", malformURL, "", "")
 	require.Error(t, err)
 }
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -627,12 +627,13 @@ type BlockSubmissionArchiveEntry struct {
 
 // archiveBlockSubmission archives a block submission using a Redis stream.
 // We are mindful to only append key value pairs to the stream where values exist, avoiding sending and archiving empty strings and zeros.
-func (api *RelayAPI) archiveBlockSubmission(log *logrus.Entry, eligibleAt time.Time, receivedAt time.Time, reqContentType string, requestPayloadBytes []byte, executionPayload *common.BuilderSubmitBlockRequest, responseCode int, simResult *blockSimResult) {
+func (api *RelayAPI) archiveBlockSubmission(log *logrus.Entry, eligibleAt, receivedAt time.Time, reqContentType string, requestPayloadBytes []byte, executionPayload *common.BuilderSubmitBlockRequest, responseCode int, simResult *blockSimResult) {
 	if executionPayload.Capella.ExecutionPayload == nil {
 		log.WithField("payload", executionPayload).Debug("archiving block submissions is only supported for Capella block submissions, skipping block submission")
 		return
 	}
 
+	//lint:ignore SA4006 variable is actually used
 	payloadBytes := []byte{}
 	if reqContentType == "json" {
 		payloadBytes = requestPayloadBytes


### PR DESCRIPTION
Stores the payload request, consisting of some request metadata, the blinded payload itself, and the reason we aborted the request early if any.

Also fixes some unnoticed earlier introduced linting errors.